### PR TITLE
feat: LettuceRedisClientをDisposableのサブタイプにして廃棄処理対象に指定できるように修正

### DIFF
--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceClusterRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceClusterRedisClient.java
@@ -117,7 +117,7 @@ public class LettuceClusterRedisClient extends AbstractLettuceRedisClient implem
     }
 
     @Override
-    public void shutdown() {
+    public void dispose() {
         connection.close();
         client.shutdown();
     }

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceMasterReplicaRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceMasterReplicaRedisClient.java
@@ -114,7 +114,7 @@ public class LettuceMasterReplicaRedisClient extends AbstractLettuceRedisClient 
     }
 
     @Override
-    public void shutdown() {
+    public void dispose() {
         connection.close();
         client.shutdown();
     }

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceRedisClient.java
@@ -1,11 +1,13 @@
 package nablarch.integration.redisstore.lettuce;
 
+import nablarch.core.repository.disposal.Disposable;
+
 /**
  * セッションストアの実装に必要となる Redis コマンドを定義したインターフェース。
  *
  * @author Tanaka Tomoyuki
  */
-public interface LettuceRedisClient {
+public interface LettuceRedisClient extends Disposable {
 
     /**
      * 実装クラスを識別する種別を取得する。
@@ -72,5 +74,6 @@ public interface LettuceRedisClient {
     /**
      * Redisサーバーとの接続を閉じる。
      */
-    void shutdown();
+    @Override
+    void dispose();
 }

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceSimpleRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceSimpleRedisClient.java
@@ -112,7 +112,7 @@ public class LettuceSimpleRedisClient extends AbstractLettuceRedisClient impleme
     }
 
     @Override
-    public void shutdown() {
+    public void dispose() {
         connection.close();
         client.shutdown();
     }

--- a/src/test/java/nablarch/integration/redisstore/lettuce/AbstractLettuceRedisClientTest.java
+++ b/src/test/java/nablarch/integration/redisstore/lettuce/AbstractLettuceRedisClientTest.java
@@ -22,7 +22,7 @@ public class AbstractLettuceRedisClientTest {
             @Override public byte[] get(String key) { return new byte[0]; }
             @Override public void del(String key) {}
             @Override public boolean exists(String key) { return false; }
-            @Override public void shutdown() {}
+            @Override public void dispose() {}
         };
 
         String actual = sut.getType();

--- a/src/test/java/nablarch/integration/redisstore/lettuce/LettuceRedisClientProviderTest.java
+++ b/src/test/java/nablarch/integration/redisstore/lettuce/LettuceRedisClientProviderTest.java
@@ -89,6 +89,6 @@ public class LettuceRedisClientProviderTest {
         @Override public byte[] get(String key) { return new byte[0]; }
         @Override public void del(String key) {}
         @Override public boolean exists(String key) { return false; }
-        @Override public void shutdown() {}
+        @Override public void dispose() {}
     }
 }


### PR DESCRIPTION
`LettuceRedisClient` が `Disposable` を継承するようにして、もともと `LettuceRedisClient` に定義していた `shutdown()` メソッドの名前を `dispose()` に置き換えました。

接続のクローズ処理はクライアントが共通して持つべき機能だと思ったので、 `LettuceRedisClient` が `Disposable` を継承するようにしました。

`shutdown()` は、とりあえず廃棄する手段を用意しておくために定義しておいたもので他のところから利用されていないので、 `dispose()` に一本化しました。

