### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/integration/redisstore/lettuce/AbstractLettuceRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/AbstractLettuceRedisClient.java
@@ -1,5 +1,7 @@
 package nablarch.integration.redisstore.lettuce;
 
+import nablarch.core.util.annotation.Published;
+
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -7,6 +9,7 @@ import java.nio.charset.StandardCharsets;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public abstract class AbstractLettuceRedisClient implements LettuceRedisClient {
     private final String type;
 

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceClusterRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceClusterRedisClient.java
@@ -6,6 +6,7 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import nablarch.core.repository.initialization.Initializable;
+import nablarch.core.util.annotation.Published;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class LettuceClusterRedisClient extends AbstractLettuceRedisClient implements Initializable {
     private RedisClusterClient client;
     private StatefulRedisClusterConnection<byte[], byte[]> connection;

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceMasterReplicaRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceMasterReplicaRedisClient.java
@@ -7,6 +7,7 @@ import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.masterreplica.MasterReplica;
 import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 import nablarch.core.repository.initialization.Initializable;
+import nablarch.core.util.annotation.Published;
 
 /**
  * Master/Replica 構成の Redis に接続するための {@link LettuceRedisClient} 実装。
@@ -16,6 +17,7 @@ import nablarch.core.repository.initialization.Initializable;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class LettuceMasterReplicaRedisClient extends AbstractLettuceRedisClient implements Initializable {
     private RedisClient client;
     private StatefulRedisMasterReplicaConnection<byte[], byte[]> connection;

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceRedisClient.java
@@ -1,12 +1,14 @@
 package nablarch.integration.redisstore.lettuce;
 
 import nablarch.core.repository.disposal.Disposable;
+import nablarch.core.util.annotation.Published;
 
 /**
  * セッションストアの実装に必要となる Redis コマンドを定義したインターフェース。
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public interface LettuceRedisClient extends Disposable {
 
     /**

--- a/src/main/java/nablarch/integration/redisstore/lettuce/LettuceSimpleRedisClient.java
+++ b/src/main/java/nablarch/integration/redisstore/lettuce/LettuceSimpleRedisClient.java
@@ -5,6 +5,7 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import nablarch.core.repository.initialization.Initializable;
+import nablarch.core.util.annotation.Published;
 
 /**
  * 単一の Redis インスタンスに直接接続するためのシンプルな {@link LettuceRedisClient} 実装クラス。
@@ -14,6 +15,7 @@ import nablarch.core.repository.initialization.Initializable;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class LettuceSimpleRedisClient extends AbstractLettuceRedisClient implements Initializable {
     private RedisClient client;
     private StatefulRedisConnection<byte[], byte[]> connection;


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/lettuce_adaptor/redisstore_lettuce_adaptor.html#redisstore-redis-client-config)には、Redisクライアントクラスを継承してカスタマイズするよう案内されているにも関わらず、公開APIとはなっていませんでした。そのため、以下のクライアントクラスについてアーキテクト向けの公開APIとしました。

- `LettuceSimpleRedisClient`
- `LettuceMasterReplicaRedisClient`
- `LettuceClusterRedisClient`

また、サブクラス公開に合わせて以下のクラスもアーキテクト向けの公開APIとしました。

- `AbstractLettuceRedisClient`
- `LettuceRedisClient`